### PR TITLE
MT-55 Registration

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VITE_BASE_URL="https://prod-chat.duckdns.org/api/"
+VITE_TEST_URL="https://test-chat.duckdns.org/api/"

--- a/index.html
+++ b/index.html
@@ -47,7 +47,6 @@
           .then((response) => response.json())
           .then((result) => {
             console.log({ result });
-            //document.cookie = "token=kjkjkj";
             console.log(document.cookie);
             fetch(`${server}/profile/avatar/`, {
               method: "GET",

--- a/src/App.css
+++ b/src/App.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.logo {
+/* .logo {
   height: 6em;
   padding: 1.5em;
   will-change: filter;
@@ -40,4 +40,4 @@
 
 .read-the-docs {
   color: #888;
-}
+} */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useState } from "react";
+import React, { useEffect, useContext } from "react";
 import "./App.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import UserProfile from "./pages/UserProfile/UserProfile";
 import Login from "./pages/auth/Login/Login";
 import Signup from "./pages/auth/Signup/Signup";
 import CheckYourEmail from "./pages/auth/Signup/CheckYourEmail";
+import ConfirmEmail from "./pages/auth/Signup/ConfirmEmail";
 import { AuthContext } from "./pages/auth/AuthContext/AuthContext";
 
 function App() {
@@ -33,6 +34,7 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/check-your-email" element={<CheckYourEmail />} />
+        <Route path="/confirm-email" element={<ConfirmEmail />} />
       </Routes>
     </Router>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import Home from "./pages/Home";
 import Header from "./shared/Header/Header";
 import UserProfile from "./pages/UserProfile/UserProfile";
 import Login from "./pages/auth/Login/Login";
+import Signup from "./pages/auth/Signup/Signup";
+import CheckYourEmail from "./pages/auth/Signup/CheckYourEmail";
 import { AuthContext } from "./pages/auth/AuthContext/AuthContext";
 
 function App() {
@@ -29,6 +31,8 @@ function App() {
         <Route path="/user-profile/:id" element={<UserProfile />} />
         <Route path="/home" element={<Home username={username} />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route path="/check-your-email" element={<CheckYourEmail />} />
       </Routes>
     </Router>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,22 @@
 import React from "react";
-import { testServerURL } from "../apiUrls/apiUrls";
+// import { testServerURL } from "../apiUrls/apiUrls";
 
 export default function Home({ username }: { username: string | null }) {
   const getImg = () => {
-    fetch(`${import.meta.env.BASE_URL}api/profile/avatar/`, {
-      method: "GET",
-      credentials: "include",
-    })
-      .then((response) => response.json())
-      .then((result) => {
-        console.log({ result });
-      });
+    const URL = "https://test-chat.duckdns.org/api/profile/";
+    // const URL = `${import.meta.env.TEST_URL}profile/avatar/`;
+    try {
+      fetch(URL, {
+        method: "GET",
+        credentials: "include",
+      })
+        .then((response) => response.json())
+        .then((result) => {
+          console.log({ result });
+        });
+    } catch (err) {
+      console.error(`ERRROR: ${err}`);
+    }
   };
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { testServerURL } from "../apiUrls/apiUrls";
 
 export default function Home({ username }: { username: string | null }) {
   const getImg = () => {
-    fetch(`${testServerURL}api/profile/avatar/`, {
+    fetch(`${import.meta.env.BASE_URL}api/profile/avatar/`, {
       method: "GET",
       credentials: "include",
     })

--- a/src/pages/auth/Login/Login.module.css
+++ b/src/pages/auth/Login/Login.module.css
@@ -2,4 +2,5 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  align-items: center;
 }/*# sourceMappingURL=Login.module.css.map */

--- a/src/pages/auth/Login/Login.module.css.map
+++ b/src/pages/auth/Login/Login.module.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["Login.module.scss","Login.module.css"],"names":[],"mappings":"AAAA;EACE,aAAA;EACA,sBAAA;EACA,SAAA;ACCF","file":"Login.module.css"}
+{"version":3,"sources":["Login.module.scss","Login.module.css"],"names":[],"mappings":"AAAA;EACE,aAAA;EACA,sBAAA;EACA,SAAA;EACA,mBAAA;ACCF","file":"Login.module.css"}

--- a/src/pages/auth/Login/Login.module.scss
+++ b/src/pages/auth/Login/Login.module.scss
@@ -2,4 +2,5 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  align-items: center;
 }

--- a/src/pages/auth/Login/Login.tsx
+++ b/src/pages/auth/Login/Login.tsx
@@ -25,7 +25,8 @@ export default function Login() {
 
   const onSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const url = `${import.meta.env.BASE_URL}login/`;
+    // const url = `${import.meta.env.TEST_URL}login/`;
+    const url = "https://test-chat.duckdns.org/api/login/";
 
     const data = {
       username: formState.username,

--- a/src/pages/auth/Login/Login.tsx
+++ b/src/pages/auth/Login/Login.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import styles from "./Login.module.scss";
 import { AuthContext } from "../AuthContext/AuthContext";
 import authService from "../../../services/auth/auth.service.tsx";
 import { localStorageService } from "../../../services/local-storage/local-storage.ts";
+import styles from "./Login.module.scss";
 
 export default function Login() {
   const { setUsername } = useContext(AuthContext);
@@ -26,17 +26,23 @@ export default function Login() {
   const onSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
     // const url = `${import.meta.env.TEST_URL}login/`;
-    const url = "https://test-chat.duckdns.org/api/login/";
+    try {
+      const url = "https://test-chat.duckdns.org/api/login/";
 
-    const data = {
-      username: formState.username,
-      password: formState.password,
-    };
-    const response = await authService.login(url, data);
-    if (!response) throw new Error("Response is undefined");
-    setUsername(response.user.username);
-    localStorageService.set("user", response.user);
-    navigate("/home");
+      const data = {
+        username: formState.username,
+        password: formState.password,
+      };
+      const response = await authService.login(url, data);
+      // console.log(response);
+      // if (!response) throw new Error("Response is undefined");
+
+      setUsername(response.user.username);
+      localStorageService.set("user", response.user);
+      navigate("/home");
+    } catch (error: any) {
+      alert(error.Invalid);
+    }
   };
 
   return (

--- a/src/pages/auth/Signup/CheckYourEmail.tsx
+++ b/src/pages/auth/Signup/CheckYourEmail.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function CheckYourEmail() {
+  return (
+    <div className="CheckYourEmail">
+      <h3>Please check your email for a verification link.</h3>
+    </div>
+  );
+}

--- a/src/pages/auth/Signup/ConfirmEmail.tsx
+++ b/src/pages/auth/Signup/ConfirmEmail.tsx
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import authService from "../../../services/auth/auth.service";
+
+export default function ConfirmEmail() {
+  const [isVerified, setIsVerified] = useState(false);
+
+  useEffect(() => {
+    async function registerUser() {
+      //   console.log(window.location);
+      try {
+        const origin = window.location.origin;
+        const currentUrl = window.location.href;
+        const url = currentUrl.replace(
+          origin,
+          "https://test-chat.duckdns.org/api"
+        );
+
+        const response = await authService.confirmEmail(url);
+        if (response?.data.is_email_confirmed) {
+          setIsVerified(true);
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    registerUser();
+  }, []);
+
+  let content;
+  if (!isVerified) {
+    content = <h3>Verifying...</h3>;
+  } else {
+    content = (
+      <div>
+        Email verified. Please <Link to="/login">sign in</Link>
+      </div>
+    );
+  }
+
+  return content;
+}

--- a/src/pages/auth/Signup/Signup.tsx
+++ b/src/pages/auth/Signup/Signup.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import authService from "../../../services/auth/auth.service";
+import styles from "../Login/Login.module.css";
+
+export default function Signup() {
+  const [formState, setFormState] = useState({
+    username: "",
+    email: "",
+    password: "",
+  });
+
+  const navigate = useNavigate();
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>, type: string) => {
+    e.preventDefault();
+    setFormState({
+      ...formState,
+      [type]: e.target.value,
+    });
+  };
+
+  const handleSignup = async (e: React.ChangeEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const url = "https://test-chat.duckdns.org/api/register/";
+    const data = {
+      username: formState.username,
+      email: formState.email,
+      password: formState.password,
+    };
+
+    const response = await authService.signup(url, data);
+    console.log(response);
+    if (!response) throw new Error("Response is undefined");
+    navigate("/check-your-email");
+  };
+
+  return (
+    <div className={styles.auth_form_wrapper}>
+      <form onSubmit={handleSignup}>
+        <h3>Sign up</h3>
+        <div className={styles.auth_form_input_container}>
+          <label htmlFor="user">user name</label>
+          <input
+            type="text"
+            placeholder="user name"
+            required
+            autoComplete="off"
+            id="user"
+            value={formState.username}
+            onChange={(e) => onChange(e, "username")}
+          />
+          <label htmlFor="email">email</label>
+          <input
+            type="email"
+            placeholder="user@gmail.com"
+            required
+            autoComplete="off"
+            id="email"
+            value={formState.email}
+            onChange={(e) => onChange(e, "email")}
+          />
+          <label htmlFor="password">password</label>
+          <input
+            type="password"
+            placeholder="********"
+            required
+            autoComplete="off"
+            id="password"
+            value={formState.password}
+            onChange={(e) => onChange(e, "password")}
+          />
+        </div>
+        <button type="submit">Sign up</button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/auth/Signup/Signup.tsx
+++ b/src/pages/auth/Signup/Signup.tsx
@@ -22,18 +22,32 @@ export default function Signup() {
 
   const handleSignup = async (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
+    try {
+      const url = "https://test-chat.duckdns.org/api/register/";
+      const data = {
+        username: formState.username,
+        email: formState.email,
+        password: formState.password,
+      };
 
-    const url = "https://test-chat.duckdns.org/api/register/";
-    const data = {
-      username: formState.username,
-      email: formState.email,
-      password: formState.password,
-    };
-
-    const response = await authService.signup(url, data);
-    console.log(response);
-    if (!response) throw new Error("Response is undefined");
-    navigate("/check-your-email");
+      const response = await authService.signup(url, data);
+      console.log(response);
+      if (!response) throw new Error("Response is undefined");
+      navigate("/check-your-email");
+    } catch (error: any) {
+      if (error instanceof Array) {
+        // handle array of errors
+        error.forEach((err) => {
+          alert(err[0]);
+        });
+      } else if (error instanceof Error) {
+        // handle single error
+        console.error(error.message);
+      } else {
+        // handle unexpected error object
+        console.error(error);
+      }
+    }
   };
 
   return (

--- a/src/services/auth/auth.service.tsx
+++ b/src/services/auth/auth.service.tsx
@@ -9,7 +9,13 @@ const signup = async (url: string, data: any) => {
     });
     return response;
   } catch (err: any) {
-    console.error(err.response.data);
+    // console.error(err.response);
+    const errorResp = err.response.data;
+    const errors = [];
+    for (const err in errorResp) {
+      errors.push(errorResp[err]);
+    }
+    throw errors;
   }
 };
 

--- a/src/services/auth/auth.service.tsx
+++ b/src/services/auth/auth.service.tsx
@@ -1,4 +1,20 @@
-// import axios from "axios";
+import axios from "axios";
+
+const signup = async (url: string, data: any) => {
+  try {
+    const response = await axios({
+      url,
+      method: "POST",
+      data,
+    });
+    return response;
+  } catch (err: any) {
+    console.error(err.response.data);
+  }
+  // if (response.status !== 200) {
+  //   throw new Error("Response status is not 200");
+  // }
+};
 
 const login = async (url: string, data: unknown) => {
   const response = await fetch(url, {
@@ -20,6 +36,7 @@ const logout = () => {
 };
 
 const authService = {
+  signup,
   login,
   logout,
 };

--- a/src/services/auth/auth.service.tsx
+++ b/src/services/auth/auth.service.tsx
@@ -32,9 +32,15 @@ const login = async (url: string, data: unknown) => {
     body: JSON.stringify(data),
   });
 
-  if (!response.ok) throw new Error("Response status is not 200");
+  if (!response.ok) {
+    console.error(`An error occurred with the status: ${response.status}`);
+    const errorData = await response.json();
+    throw errorData;
+  }
+  return response.json();
 
-  return await response.json();
+  // if (!response.ok) throw new Error("Response status is not 200");
+  // return await response.json();
 };
 
 const logout = () => {

--- a/src/services/auth/auth.service.tsx
+++ b/src/services/auth/auth.service.tsx
@@ -11,9 +11,15 @@ const signup = async (url: string, data: any) => {
   } catch (err: any) {
     console.error(err.response.data);
   }
-  // if (response.status !== 200) {
-  //   throw new Error("Response status is not 200");
-  // }
+};
+
+const confirmEmail = async (url: string) => {
+  try {
+    const response = await axios.get(url);
+    return response;
+  } catch (err: any) {
+    console.error(err.response.data);
+  }
 };
 
 const login = async (url: string, data: unknown) => {
@@ -37,6 +43,7 @@ const logout = () => {
 
 const authService = {
   signup,
+  confirmEmail,
   login,
   logout,
 };

--- a/src/shared/Header/Header.tsx
+++ b/src/shared/Header/Header.tsx
@@ -13,6 +13,9 @@ export default function Header({ user }: { user: string | null }) {
         <li>
           <NavLink to={"/user-profile/1"}>User Profile</NavLink>
         </li>
+        <li>
+          <NavLink to={"/signup"}>SignUp</NavLink>
+        </li>
 
         {user ? (
           <li>


### PR DESCRIPTION
Implement User Registration

This PR adds the user registration flow to the app. It includes:

- A registration page with a form to enter username, email, and password.
- A registration API endpoint to create the user in the database.
- Error handling if the API call fails.
- Redirect to a confirmation page on successful registration.

The registration API call is made to `/api/register` and expects a POST request with JSON body containing the user details. On the server side it checks for duplicate emails and usernames before creating the user in the database.

This provides the basic user registration flow.

In the future we could improve it by displaying errors on the page (not through the annoying alert messages), adding more validation, handling forgot password, etc.